### PR TITLE
Fix sidebar not showing in mobile

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,11 +1,12 @@
 <header class="page-header">
     <div class="page-header__inner">
         <div class="page-header__sidebar">
-          <a href="/">
-            <div class="page-header__menu-btn"><button class="menu-btn ico_menu is-active"></button></div>
-            <div class="page-header__logo"><img src="/assets/degen-brand/degen-heroes-hero-transparent.png" alt="logo">
-              <span class="page-header__logo_text">Degen Heroes</span>
-            </div>
+          <div class="page-header__menu-btn">
+            <button class="menu-btn ico_menu is-active"></button>
+          </div>
+          <a class="page-header__logo" href="/">
+            <img src="/assets/degen-brand/degen-heroes-hero-transparent.png" alt="degen heroes logo">
+            <span class="page-header__logo_text">Degen Heroes</span>
           </a>
         </div>
         <div class="page-header__content">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1490,7 +1490,6 @@ a:hover {
 
 .page-header__menu-btn {
     margin-right: 30px;
-    margin-bottom: -10px;
     display: none;
 }
 
@@ -1525,14 +1524,20 @@ a:hover {
 }
 
 .page-header__logo {
-    display: block;
-    position: relative;
-    margin-left: -4px;
+    color: #1f1f1f;
+    display: flex;
+    align-items: center;
+}
+
+.page-header__logo:hover {
+    color: #646464;
 }
 
 
 .page-header__logo img {
-    max-width: 30px;
+    position: relative;
+    top: -4px;
+    max-width: 28px;
     height: auto;
     margin-right: 12px;
 }
@@ -1540,7 +1545,6 @@ a:hover {
 .page-header__logo_text {
     font-weight: bold;
     position: relative;
-    top: 11px;
     font-size: 20px;
 }
 
@@ -4496,10 +4500,6 @@ body.dark-theme #modal-help ul li {
 
     .page-header__menu-btn {
         display: block;
-    }
-
-    .page-header__logo_text {
-        display: none;
     }
 
     .sidebar.is-show + .page-main {


### PR DESCRIPTION
This adds a fix for toggling the sidebar menu in mobile and also shows the wordmark alongside the logo in mobile for recognizability.

![image](https://user-images.githubusercontent.com/1829897/162780806-64617f29-269c-4f3d-bd21-9606069e0ad0.png)
